### PR TITLE
Add Google Shopping bot

### DIFF
--- a/bots.yml
+++ b/bots.yml
@@ -87,6 +87,7 @@ google Web Preview: "Google Instant Previews crawler"
 google-site-verification: Google-Site-Verification
 google-structured-data-testing-tool: "Google-StructuredDataTestingTool"
 google-structureddatatestingtool: "Google-StructuredDataTestingTool"
+google-xrawler: "Google Shopping"
 googlebot: "Google Bot"
 googlestackdrivermonitoring-uptimechecks: "GoogleStackdriverMonitoring-UptimeChecks"
 grapeshotcrawler: "GrapeshotCrawler"

--- a/test/ua_bots.yml
+++ b/test/ua_bots.yml
@@ -29,6 +29,7 @@ GOOGLE_SITE_VERIFICATION: Mozilla/5.0 (compatible; Google-Site-Verification/1.0)
 GOOGLE_STACKDRIVER_UPTIME_CHECKS: 'GoogleStackdriverMonitoring-UptimeChecks'
 GOOGLE_STRUCTURED_DATA_TESTING_TOOL2: 'Mozilla/5.0 (compatible; Google-Structured-Data-Testing-Tool +http://developers.google.com/structured-data/testing-tool/)'
 GOOGLE_STRUCTURED_DATA_TESTING_TOOL: 'Mozilla/5.0 (compatible; X11; Linux x86_64; Google-StructuredDataTestingTool; +http://www.google.com/webmasters/tools/richsnippets)'
+GOOGLE_SHOPPING: 'google-xrawler'
 GRAPESHOT: 'Mozilla/5.0 (compatible; GrapeshotCrawler/2.0; +http://www.grapeshot.co.uk/crawler.php)'
 IMPLISENSEBOT: 'ImplisenseBot 1.0'
 JOBSEEKER: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) JobBot/5.0 (compatible; +http://www.jobseeker.com.au/bot.html) Safari/538.1'


### PR DESCRIPTION
This PR adds the Google Shopping bot to the bots.yml.

Discovered in logs + Verified with https://webmasters.stackexchange.com/questions/105560/what-is-the-google-xrawler-user-agent-used-for